### PR TITLE
Improved routing for SEO indexing

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -11,7 +11,7 @@
 	<link rel="icon" href="%PUBLIC_URL%/img/cropped-MKLizardFilled-32x32.jpg" sizes="32x32">
 
 	<!-- This is the end result of a sass build -->
-	<link href="css/index.css" rel="stylesheet">
+	<link href="/css/index.css" rel="stylesheet">
 </head>
 
 <body  ondragstart="return false;" ondrop="return false;">

--- a/public/sitemap.txt
+++ b/public/sitemap.txt
@@ -1,4 +1,4 @@
-https://edition640.makingandknowing.org/#/
-https://edition640.makingandknowing.org/#/essays
-https://edition640.makingandknowing.org/#/content/about/overview
-https://edition640.makingandknowing.org/#/content/about/manuscript
+https://edition640.makingandknowing.org/
+https://edition640.makingandknowing.org/essays
+https://edition640.makingandknowing.org/content/about/overview
+https://edition640.makingandknowing.org/content/about/manuscript

--- a/src/component/ContentView.js
+++ b/src/component/ContentView.js
@@ -3,10 +3,10 @@ import Parser from 'html-react-parser';
 import domToReact from 'html-react-parser/lib/dom-to-react';
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
-import { HashLink } from 'react-router-hash-link';
 import { dispatchAction } from '../model/ReduxStore';
 import AnnotationCard from './annotation_list_view/AnnotationCard';
 import ContentPage from './ContentPage';
+import { Link } from 'react-router-dom';
 
 class ContentView extends Component {
 
@@ -58,17 +58,17 @@ class ContentView extends Component {
                     )
                 }
 
-                if( // change anchor tag to hash link if href is relative (does not start w/ "http")
+                if( // change anchor tag to react router link if href is relative (does not start w/ "http")
                     domNode.name === 'a'
                     && !domNode.attribs.href.match(/^http/)
                 ){
                     return(
-                        <HashLink
+                        <Link
                             to={domNode.attribs.href}
                             scroll={el => scrollWithOffset(el)}
                         >
                             {domToReact(domNode.children, parserOptions)}
-                        </HashLink>
+                        </Link>
                     )
                 }
 

--- a/src/component/ContentView.js
+++ b/src/component/ContentView.js
@@ -119,7 +119,7 @@ class ContentView extends Component {
                         </div>
                         <div className='flex-parent jc-space-around'>
                             <a className='cta-link with-icon video-link' onClick={this.onVideoDialogOpen}>Watch Video</a>
-                            <a className='cta-link with-icon' href='#/content/about'>Learn More</a>
+                            <a className='cta-link with-icon' href='/content/about'>Learn More</a>
                         </div>
                     </div>
                     {isWidthUp('sm', this.props.width) &&
@@ -143,16 +143,16 @@ class ContentView extends Component {
                             </p>
                             {isWidthUp('sm', this.props.width) &&
                                 <div className='flex-parent links-container full-width'>
-                                    <a className='cta-link with-icon' href='#/folios'>Read the Edition</a>
-                                    <a className='cta-link with-icon' href='#/content/resources'>Resources</a>
+                                    <a className='cta-link with-icon' href='/folios'>Read the Edition</a>
+                                    <a className='cta-link with-icon' href='/content/resources'>Resources</a>
                                 </div>
                             }
                         </div>
                     </div>
                     {!isWidthUp('sm', this.props.width) &&
                         <div className='flex-parent links-container full-width'>
-                            <a className='cta-link with-icon' href='#/folios'>Read the Edition</a>
-                            <a className='cta-link with-icon' href='#/content/resources'>Resources</a>
+                            <a className='cta-link with-icon' href='/folios'>Read the Edition</a>
+                            <a className='cta-link with-icon' href='/content/resources'>Resources</a>
                         </div>
                     }
                 </div>

--- a/src/component/DiploMatic.js
+++ b/src/component/DiploMatic.js
@@ -6,7 +6,7 @@ import PropTypes from 'prop-types';
 import React, { Component, useRef } from 'react';
 import ReactGA from 'react-ga4';
 import { connect, Provider } from 'react-redux';
-import { HashRouter, Route, Switch } from 'react-router-dom';
+import { BrowserRouter as Router, Route, Switch, Redirect } from 'react-router-dom';
 import { dispatchAction } from '../model/ReduxStore';
 import AnnotationView from './AnnotationView';
 import AnnotationListView from './annotation_list_view/AnnotationListView';
@@ -235,6 +235,17 @@ class DiploMatic extends Component {
 		return (
 			<div id="content">
 				<Switch>
+					<Route
+						path="/"
+						exact
+						render={(props) =>
+						props.location.hash ? (
+							<Redirect to={props.location.hash.replace("#", "")} />
+						) : (
+							this.renderIndexPage(props)
+						)
+						}
+					/>
 					<Route path="/" render={this.renderIndexPage} exact/>
 					<Route path="/content" render={this.renderContentView}/>
 					<Route path="/entries" component={EntryListView}/>
@@ -303,14 +314,14 @@ class DiploMatic extends Component {
 		}
 		return (
 			<Provider store={this.props.store}>
-				<HashRouter>
+				<Router>
 					<div id="diplomatic" className={fixedFrameModeClass}>
 						<RouteListener/>
 						{ this.renderHeader(fixedFrameModeClass) }
 						{ this.renderContent() }
 						{ this.renderFooter(fixedFrameModeClass) }
 					</div>	
-				</HashRouter>
+				</Router>
 			</Provider>
 		);
 	}

--- a/src/component/EntryListView.js
+++ b/src/component/EntryListView.js
@@ -239,7 +239,7 @@ class EntryListView extends Component {
                   <div id="entry-list-view">
                         <div id="list-header">
                               <Typography id='entry-header' variant='h1' gutterBottom>Entries ({entryList.length})</Typography>
-                              <Typography>Ms. Fr. 640 consists almost entirely of distinct “entries,” i.e., units of text with titles. They have been grouped into <a href="#/content/resources">categories</a> to help browse the manuscript. Within entries, meaningful terms have been <a href="#/content/resources/principles">tagged</a>.</Typography><br />
+                              <Typography>Ms. Fr. 640 consists almost entirely of distinct “entries,” i.e., units of text with titles. They have been grouped into <a href="/content/resources">categories</a> to help browse the manuscript. Within entries, meaningful terms have been <a href="/content/resources/principles">tagged</a>.</Typography><br />
                               <Typography>Filter the List of Entries by selecting one or more "category" and/or "tag" buttons.</Typography><br />
                         </div>
                         <div className="filter-bar">

--- a/src/component/EntryListView.js
+++ b/src/component/EntryListView.js
@@ -3,6 +3,7 @@ import {connect} from 'react-redux';
 import ReactList from 'react-list';
 import {Typography,  Chip, Avatar } from '@material-ui/core';
 import { Link } from '@material-ui/core';
+import { Link as RouterLink } from 'react-router-dom';
 import ExpansionPanel from '@material-ui/core/ExpansionPanel';
 import ExpansionPanelSummary from '@material-ui/core/ExpansionPanelSummary';
 import ExpansionPanelDetails from '@material-ui/core/ExpansionPanelDetails';
@@ -43,7 +44,8 @@ class EntryListView extends Component {
                               annotationItem = (
                                     <Link 
                                           key={key} 
-                                          onClick={e => {this.props.history.push(annotationURL)}} 
+                                          component={RouterLink}
+                                          to={annotationURL} 
                                     >
                                           {annotation.name}
                                     </Link>
@@ -113,7 +115,7 @@ class EntryListView extends Component {
                         <ExpansionPanel className="entry" key={entry.id} onChange={this.toggleIconButton}>
                               <ExpansionPanelSummary expandIcon={ tags.length >0 ? (<div><ExpandMoreIcon className="colapse-button" /></div>):''}>
                                     <div className={"detail-container"}>
-                                          <Link onClick={e => {this.props.history.push(folioURL)}} ><Typography variant="h6">{`${entry.displayHeading} - ${entry.folio_display}`}</Typography></Link>
+                                          <Link component={RouterLink} to={folioURL}><Typography variant="h6">{`${entry.displayHeading} - ${entry.folio_display}`}</Typography></Link>
                                           <div className='entry-categories'><Typography>Categories: </Typography>{categoryChips}</div>
                                           { this.renderAnnotationList(entry) }
                                           <div className="entry-chips">{mentionRow}</div>

--- a/src/component/GlossaryView.js
+++ b/src/component/GlossaryView.js
@@ -113,7 +113,7 @@ class GlossaryView extends Component {
                   <div id="glossaryViewInner">
                         <div id="glossaryContent">
                               <Typography variant='h2' className="title">Glossary</Typography>
-                              <Typography className="subtitle">For short titles, e.g., [COT1611], see <a href="#/content/resources/bibliography">Bibliography</a>.</Typography>
+                              <Typography className="subtitle">For short titles, e.g., [COT1611], see <a href="/content/resources/bibliography">Bibliography</a>.</Typography>
                               <div className="cite-instructions">
                                 <Typography className='cite-header'>How to Cite</Typography>
                                 <Typography>“Glossary.” In <i>Secrets of Craft and Nature in Renaissance France. A Digital Critical Edition and English Translation of BnF Ms. Fr. 640</i>, edited by Making and Knowing Project, Pamela H. Smith, Naomi Rosenkranz, Tianna Helena Uchacz, Tillmann Taape, Clément Godbarge, Sophie Pitman, Jenny Boulboullé, Joel Klein, Donna Bilak, Marc Smith, and Terry Catapano. New York: Making and Knowing Project, 2020. <a href="https://edition640.makingandknowing.org/#/folios/1r/f/1r/glossary">https://edition640.makingandknowing.org/#/folios/1r/f/1r/glossary</a>.</Typography>

--- a/src/component/HelpPopper.js
+++ b/src/component/HelpPopper.js
@@ -74,7 +74,7 @@ const HelpPopper=(props)=>{
                                                 </table>
                                           </div>
                                     </List>
-                                    <Typography>See <a href="#/content/how-to-use">How to Use</a> for more information.</Typography>
+                                    <Typography>See <a href="/content/how-to-use">How to Use</a> for more information.</Typography>
                               </div>                             
                         </Paper>
                         </Fade>

--- a/src/component/MainMenu.js
+++ b/src/component/MainMenu.js
@@ -50,13 +50,13 @@ class MainMenu extends React.Component {
             } else if(topNavItem.label) {
                 const activeClass = currentRoute === topNavItem.route ? 'active' : ''
                 topNavItems.push( 
-                <a 
+                <Link 
                     className={`cta-link nav-item ${activeClass}`} 
                     key={itemKey} 
-                    onClick={()=>{this.navTo(topNavItem.route)}}
+                    to={topNavItem.route}
                 >
                     {topNavItem.label}
-                </a> 
+                </Link> 
                 )
             }
         }


### PR DESCRIPTION
### In this PR
- Updates the site routing to use the `BrowserRouter` rather than `HashRouter`. This has the advantage of improved discoverability for search indexing scripts, specifically Google, which does not deal well with hash routes.
- To maintain compatibility with existing links, a new route is added that redirects any hash route to its non-hash counterpart (e.g. `/#/essays` will automatically redirect to `/essays`).
- To further facilitate search indexing, many of the internal links such as the main navigation and the links in the `EntryListView` are changed to use the React router `Link` component, which will result in an actual link with an `href` tag rather than relying on JavaScript `onClick` actions for navigation.

Note that to make the use of `BrowserRouter` compatible with hosting on S3/Cloudfront, a custom error handler must be added to the distribution on Cloudfront that redirects 403 status responses to `/index.html` with status 200.

### Testing Notes
A testing build is live at https://edition-dev.makingandknowing.org/ . This should be tested to make sure that...
- All internal site navigation functions as expected, including the edition viewer itself (https://edition-dev.makingandknowing.org/folios);
- Navigating directly to a page of the site (in other words, not getting there from the home page with internal navigation) successfully loads the correct page;
- Links of the current style containing the `#` successfully redirect to the right page (e.g. https://edition-dev.makingandknowing.org/#/essays)